### PR TITLE
fix: absolute path for polyfills to avoid recursive room path

### DIFF
--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -676,7 +676,7 @@ class Room extends EventEmitter {
       onStatus: (msg, isError) => {
         participant.setConnectionStatus(isError ? "failed" : "connected");
       },
-      audioWorkletUrl: "workers/audio-worklet1.js",
+      audioWorkletUrl: "/workers/audio-worklet1.js",
       mstgPolyfillUrl: "/polyfills/MSTG_polyfill.js",
     });
     // Add to audio mixer

--- a/src/core/Room.js
+++ b/src/core/Room.js
@@ -677,7 +677,7 @@ class Room extends EventEmitter {
         participant.setConnectionStatus(isError ? "failed" : "connected");
       },
       audioWorkletUrl: "workers/audio-worklet1.js",
-      mstgPolyfillUrl: "polyfills/MSTG_polyfill.js",
+      mstgPolyfillUrl: "/polyfills/MSTG_polyfill.js",
     });
     // Add to audio mixer
     if (this.audioMixer) {

--- a/src/media/Publisher.js
+++ b/src/media/Publisher.js
@@ -426,7 +426,7 @@ export default class Publisher extends EventEmitter {
 
     await this.sendPublisherState();
 
-    const workerInterval = new Worker("polyfills/intervalWorker.js");
+    const workerInterval = new Worker("/polyfills/intervalWorker.js");
     workerInterval.postMessage({ interval: 1000 });
     let lastPingTime = Date.now();
 
@@ -608,7 +608,7 @@ export default class Publisher extends EventEmitter {
       encoderObj.encoder.configure(encoderObj.config);
     });
 
-    const triggerWorker = new Worker("polyfills/triggerWorker.js");
+    const triggerWorker = new Worker("/polyfills/triggerWorker.js");
     triggerWorker.postMessage({ frameRate: this.currentConfig.framerate });
 
     const track = this.stream.getVideoTracks()[0];
@@ -1019,7 +1019,7 @@ export default class Publisher extends EventEmitter {
       }
 
       // Start video processing
-      const triggerWorker = new Worker("polyfills/triggerWorker.js");
+      const triggerWorker = new Worker("/polyfills/triggerWorker.js");
       triggerWorker.postMessage({ frameRate: screenConfig.framerate });
 
       this.screenVideoProcessor = new MediaStreamTrackProcessor(

--- a/src/media/Subscriber.js
+++ b/src/media/Subscriber.js
@@ -15,9 +15,9 @@ class Subscriber extends EventEmitter {
     this.isOwnStream = config.isOwnStream || false;
 
     // Media configuration
-    this.mediaWorkerUrl = config.mediaWorkerUrl || "workers/media-worker-ab.js";
+    this.mediaWorkerUrl = config.mediaWorkerUrl || "/workers/media-worker-ab.js";
     this.audioWorkletUrl =
-      config.audioWorkletUrl || "workers/audio-worklet1.js";
+      config.audioWorkletUrl || "/workers/audio-worklet1.js";
     this.mstgPolyfillUrl =
       config.mstgPolyfillUrl || "/polyfills/MSTG_polyfill.js";
 

--- a/src/media/Subscriber.js
+++ b/src/media/Subscriber.js
@@ -19,7 +19,7 @@ class Subscriber extends EventEmitter {
     this.audioWorkletUrl =
       config.audioWorkletUrl || "workers/audio-worklet1.js";
     this.mstgPolyfillUrl =
-      config.mstgPolyfillUrl || "polyfills/MSTG_polyfill.js";
+      config.mstgPolyfillUrl || "/polyfills/MSTG_polyfill.js";
 
     // State
     this.isStarted = false;


### PR DESCRIPTION
Relative path for polyfills would cause wrong import path for nested room route.
For example /rooms/{roomCode} would resolve intervalWorker.js at /room/polyfills/intervalWorker.js instead of consistent path.